### PR TITLE
Add equals method for DoubleArrays

### DIFF
--- a/src/main/scala/nl/biopet/utils/DoubleArray.scala
+++ b/src/main/scala/nl/biopet/utils/DoubleArray.scala
@@ -44,7 +44,12 @@ case class DoubleArray[T](values: IndexedSeq[T], counts: IndexedSeq[Long]) {
   def toMap: Map[T, Long] = this.values.zip(this.counts).toMap
 
   def toJson: JsValue = Json.toJson(this)
+
+  def ==(other: DoubleArray[T]): Boolean = {
+    this.toMap == other.toMap
+  }
 }
+
 object DoubleArray {
 
   /**

--- a/src/test/scala/nl/biopet/utils/DoubleArrayTest.scala
+++ b/src/test/scala/nl/biopet/utils/DoubleArrayTest.scala
@@ -103,4 +103,12 @@ class DoubleArrayTest extends BiopetTest {
       DoubleArray.fromJson[Int](Json.parse(jsonString)) shouldBe doubleArray
     }.getMessage should include("JsError")
   }
+
+  @Test
+  def testDoubleArrayEquals(): Unit = {
+    // Order should not matter. 3->3, 2->2 , 1->1 so these are equal.
+    DoubleArray(IndexedSeq(1, 2, 3), IndexedSeq(1, 2, 3)) == DoubleArray(
+      IndexedSeq(3, 2, 1),
+      IndexedSeq(3, 2, 1)) shouldBe true
+  }
 }


### PR DESCRIPTION
Equality should be determined by the hashmap. Not by the order of the arrays. These might differ between instances that yield the same hashmap.

----

### Checklist (never delete this)

- [x] Each method/class/object/trait should have scaladocs
- [x] Added methods are unit tested
- [x] Test coverage may not drop
- [x] Documentation should be updated if required
